### PR TITLE
Rename admin CSS class "field-box" to "fieldBox".

### DIFF
--- a/grappelli_safe/static/grappelli/css/forms.css
+++ b/grappelli_safe/static/grappelli/css/forms.css
@@ -111,7 +111,7 @@ form .aligned input + label + .help {
 td .help {
     margin-bottom: 3px; padding: 0;
 }
-fieldset .field-box {
+fieldset .fieldBox {
     float: left;
     margin-right: 45px;
     white-space: nowrap;

--- a/grappelli_safe/static/grappelli/css/rtl.css
+++ b/grappelli_safe/static/grappelli/css/rtl.css
@@ -238,7 +238,7 @@ form ul.inline li {
     padding-left: 7px;
 }
 
-fieldset .field-box {
+fieldset .fieldBox {
     float: right;
     margin-left: 20px;
 }


### PR DESCRIPTION
In Django 2.1, [the CSS class "field-box" was renamed to "fieldBox"](https://github.com/django/django/commit/5d4d62bf4fe887fcd30f9f0449de07ae76ea5968) to address [Django bug #29248](https://code.djangoproject.com/ticket/29248).  This patch, in conjuction with an equivalent patch for the Mezzanine repo, incorporates this change into Mezzanine.

Without this patch, models that have multiple fields set to display on the same line via their `fields` or `fieldsets` definitions are no longer rendered correctly in Mezzanine's admin when running on Django >= 2.1.  (The example Mezzanine site contents do not rely on any models that do this, so this error is not immediately apparent on simple test sites.)

It should be noted that this patch breaks backwards compatibility with Django 1.11.
