### PR TITLE
Use "select[multiple]" in CSS selectors.

### DIFF
--- a/grappelli_safe/static/grappelli/css/forms.css
+++ b/grappelli_safe/static/grappelli/css/forms.css
@@ -214,7 +214,7 @@ select {
     padding: 4px 3px 4px 0;
     height: 25px;
 }
-select[multiple=multiple] {
+select[multiple] {
     padding-left: 1px;
     height: 160px;
 }

--- a/grappelli_safe/static/grappelli/css/widgets.css
+++ b/grappelli_safe/static/grappelli/css/widgets.css
@@ -56,7 +56,7 @@
     min-height: 300px;
     width: 100%;
 }
-.selector select[multiple=multiple] {
+.selector select[multiple] {
     margin: 0; padding-left: 3px;
     width: 100%;
     border-top: 1px solid #d0d0d0;
@@ -64,10 +64,10 @@
     border-left: none;
     -moz-border-radius: 0; -webkit-border-radius: 0; border-radius: 0;
 }
-.selector.stacked select[multiple=multiple] {
+.selector.stacked select[multiple] {
     width: 698px;
 }
-.selector-chosen select[multiple=multiple] {
+.selector-chosen select[multiple] {
     height: 232px;
 }
 .selector h2 + select {


### PR DESCRIPTION
There was [a change to Django 2.1](https://github.com/django/django/commit/47d238b69602711c06c369a5555bb554a4b3f7fb#diff-aee6730bae795d31efec3c5d014804a9) to address [Django bug #29041](https://code.djangoproject.com/ticket/29041) that currently has a negative effect in the Mezzanine admin.  The problem can be verified by looking at the "Sites" selection box on the "Change user" page of a stock Mezzanine demo site.  Previously, under Django <= 1.11, this was a much taller field.  Without the patch in this pull request, the field element no longer matches the proper CSS selectors, so its height is limited to a single line.

Since Django has moved to using "multiple" as a boolean value, I believe that Mezzanine will probably follow suit.  Currently, however, this appears to be a mixed bag in Mezzanine.  Under Django 1.11, all of the "select" tags used the 'multiple="multiple"' attribute style.  With the current 2.2-compat branches, some of the "select" tags now render with the new boolean style, while some of the tags still render with the old attribute style.  (For instance, on the "Change user" page, "Available user permissions" uses the new boolean style, while "Chosen user permissions" uses the old 'multiple="multiple"' format.)

I have not been able to find the cause of this discrepancy yet, but the edited CSS selectors in this patch will match elements using both the old and new value types.  So, there should be no negative impact on Mezzanine from this patch at the moment, and these selector values will continue to be the correct values after the discrepancy is fixed, too.